### PR TITLE
Implemented the Youtube API to allow videos to be played on video page

### DIFF
--- a/ToBeRenamed.Tests/Commands/CreateVideoTests.cs
+++ b/ToBeRenamed.Tests/Commands/CreateVideoTests.cs
@@ -43,8 +43,8 @@ namespace ToBeRenamed.Tests.Commands
             
             // Create two videos for library
             const string vidTitle = "Video Title";
-            const string videoUrl = "Video URL";
-            const string videoUrl2 = "Video URL2";
+            const string videoUrl = "https://www.youtube.com/watch?v=-O5kNPlUV7w";
+            const string videoUrl2 = "https://www.youtube.com/watch?v=-O5kNPlUV7a";
             const string vidDescription = "Video description";
             
             var createVideosRequest1 = new CreateVideo(user.Id, libraryId, vidTitle, videoUrl, vidDescription);

--- a/ToBeRenamed.Tests/Queries/GetVideoByIdTests.cs
+++ b/ToBeRenamed.Tests/Queries/GetVideoByIdTests.cs
@@ -44,7 +44,7 @@ namespace ToBeRenamed.Tests.Queries
             
             // Create two videos for library
             const string videoTitle = "Video Title";
-            const string videoUrl = "Video URL";
+            const string videoUrl = "https://www.youtube.com/watch?v=-O5kNPlUV7w";
             const string videoDescription = "Video Description";
             
             var createVideosRequest1 = new CreateVideo(user.Id, libraryId, videoTitle, videoUrl, videoDescription);
@@ -99,7 +99,7 @@ namespace ToBeRenamed.Tests.Queries
             
             // Create two videos for library
             const string videoTitle = "Video Title";
-            const string videoUrl = "Video URL";
+            const string videoUrl = "https://www.youtube.com/watch?v=-O5kNPlUV7w";
             const string videoDescription = "Video Description";
             
             var createVideosRequest1 = new CreateVideo(user.Id, libraryId, videoTitle, videoUrl, videoDescription);

--- a/ToBeRenamed.Tests/Queries/GetVideoByIdTests.cs
+++ b/ToBeRenamed.Tests/Queries/GetVideoByIdTests.cs
@@ -1,0 +1,130 @@
+using System;
+using System.Threading.Tasks;
+using ToBeRenamed.Commands;
+using ToBeRenamed.Queries;
+using Xunit;
+using System.Linq;
+
+namespace ToBeRenamed.Tests.Queries
+{
+    public class GetVideoByIdTests : IClassFixture<DatabaseFixture>
+    {
+        private readonly DatabaseFixture _fixture;
+        
+        public GetVideoByIdTests(DatabaseFixture fixture)
+        {
+            _fixture = fixture;
+        }
+        
+        [Fact]
+        [ResetDatabase]
+        public async Task Should_ReturnCorrectVideo_When_GivenValidId()
+        {
+            // Create a test user
+            var userRequest = new CreateUserWithoutAuth("Alice");
+            var user = await _fixture.SendAsync(userRequest);
+
+            const string title = "My Fantastic Library";
+            const string description = "A suitable description.";
+            
+            // User creates library
+            var createLibraryRequest = new CreateLibrary(user.Id, title, description);
+            await _fixture.SendAsync(createLibraryRequest);
+            
+            // Get libraries just created by user
+            var getLibrariesRequest = new GetLibrariesForUser(user.Id);
+            var libraries = await _fixture.SendAsync(getLibrariesRequest);
+            
+            // Make sure there's only one library
+            var libraryDtos = libraries.ToList();
+            Assert.Single(libraryDtos);
+            
+            // Get id of the single library
+            var libraryId = libraryDtos.ToList().ElementAt(0).Id;
+            
+            // Create two videos for library
+            const string videoTitle = "Video Title";
+            const string videoUrl = "Video URL";
+            const string videoDescription = "Video Description";
+            
+            var createVideosRequest1 = new CreateVideo(user.Id, libraryId, videoTitle, videoUrl, videoDescription);
+            
+            await _fixture.SendAsync(createVideosRequest1);
+            
+            // Get videos for library
+            var getVideosRequest = new GetVideosOfLibrary(libraryId);
+            var videos = await _fixture.SendAsync(getVideosRequest);
+            
+            // Make sure correct number of videos returned
+            var videoDtos = videos.ToList();
+            Assert.Single(videoDtos);
+            
+            // Get video id
+            int videoId = videoDtos.ElementAt(0).Id;
+            
+            // Get the video using the id
+            var getVideoRequest = new GetVideoById(videoId);
+            var video = await _fixture.SendAsync(getVideoRequest);
+            
+            // Make sure the video's properties match the properties given on creation
+            Assert.Equal(videoTitle, video.Title);
+            Assert.Equal(videoDescription, video.Description);
+        }
+        
+        [Fact]
+        [ResetDatabase]
+        public async Task Should_ThrowInvalidOperationException_When_GivenInvalidId()
+        {
+            // Create a test user
+            var userRequest = new CreateUserWithoutAuth("Alice");
+            var user = await _fixture.SendAsync(userRequest);
+
+            const string title = "My Fantastic Library";
+            const string description = "A suitable description.";
+            
+            // User creates library
+            var createLibraryRequest = new CreateLibrary(user.Id, title, description);
+            await _fixture.SendAsync(createLibraryRequest);
+            
+            // Get libraries just created by user
+            var getLibrariesRequest = new GetLibrariesForUser(user.Id);
+            var libraries = await _fixture.SendAsync(getLibrariesRequest);
+            
+            // Make sure there's only one library
+            var libraryDtos = libraries.ToList();
+            Assert.Single(libraryDtos);
+            
+            // Get id of the single library
+            var libraryId = libraryDtos.ToList().ElementAt(0).Id;
+            
+            // Create two videos for library
+            const string videoTitle = "Video Title";
+            const string videoUrl = "Video URL";
+            const string videoDescription = "Video Description";
+            
+            var createVideosRequest1 = new CreateVideo(user.Id, libraryId, videoTitle, videoUrl, videoDescription);
+            
+            await _fixture.SendAsync(createVideosRequest1);
+            
+            // Get videos for library
+            var getVideosRequest = new GetVideosOfLibrary(libraryId);
+            var videos = await _fixture.SendAsync(getVideosRequest);
+            
+            // Make sure correct number of videos returned
+            var videoDtos = videos.ToList();
+            Assert.Single(videoDtos);
+            
+            // Get video id
+            int videoId = videoDtos.ElementAt(0).Id;
+            
+            // make videoId invalid
+            videoId++; 
+            
+            // Create request with invalid id
+            var getVideoRequest = new GetVideoById(videoId);
+            
+            // Make sure that an exception is thrown when video retrieval is attempted
+            await Assert.ThrowsAsync<InvalidOperationException>(async() => await _fixture.SendAsync(getVideoRequest));
+        }
+    }
+}

--- a/ToBeRenamed/Commands/CreateVideoHandler.cs
+++ b/ToBeRenamed/Commands/CreateVideoHandler.cs
@@ -23,7 +23,12 @@ namespace ToBeRenamed.Commands
             var link = request.Link;
             var description = request.Description;
 
-            var parsedUrl = link.Substring(32, 11);
+            // TODO - Remove this and add validation to make sure only valid youtube urls can get added
+            var parsedUrl = link;
+            if (link.Length == 43)
+            {
+                parsedUrl = link.Substring(32, 11);
+            }
             
             const string sql = @"
             WITH videoURLS AS (

--- a/ToBeRenamed/Commands/CreateVideoHandler.cs
+++ b/ToBeRenamed/Commands/CreateVideoHandler.cs
@@ -23,10 +23,12 @@ namespace ToBeRenamed.Commands
             var link = request.Link;
             var description = request.Description;
 
+            var parsedUrl = link.Substring(32, 11);
+            
             const string sql = @"
             WITH videoURLS AS (
                 INSERT INTO plum.video_urls (url)
-                VALUES (@link)
+                VALUES (@parsedUrl)
                 RETURNING id, url
             )
             INSERT INTO plum.videos (title, description, video_url_id, library_id)
@@ -34,7 +36,7 @@ namespace ToBeRenamed.Commands
 
             using (var cnn = _sqlConnectionFactory.GetSqlConnection())
             {
-                await cnn.ExecuteAsync(sql, new { userId, libraryId, title, link, description });
+                await cnn.ExecuteAsync(sql, new { userId, libraryId, title, parsedUrl, description });
             }
 
             return Unit.Value;

--- a/ToBeRenamed/Dtos/VideoDto.cs
+++ b/ToBeRenamed/Dtos/VideoDto.cs
@@ -7,5 +7,6 @@ namespace ToBeRenamed.Dtos
         public string Title { get; set; }
         public string Description { get; set; }
         public int Id { get; set; }
+        public string Url { get; set; }
     }
 }

--- a/ToBeRenamed/Dtos/VideoDto.cs
+++ b/ToBeRenamed/Dtos/VideoDto.cs
@@ -6,5 +6,6 @@ namespace ToBeRenamed.Dtos
     {
         public string Title { get; set; }
         public string Description { get; set; }
+        public int Id { get; set; }
     }
 }

--- a/ToBeRenamed/Pages/Library.cshtml
+++ b/ToBeRenamed/Pages/Library.cshtml
@@ -100,7 +100,7 @@
                     @foreach (var video in Model.Videos)
                     {
                         <div class="col-md-4">
-                            <a class="thumbnail" href="#">
+                            <a class="thumbnail" asp-page="/Videos/Index" asp-route-id="@video.Id">
                                 <img class="media-object"
                                      src="http://identicon.rmhdev.net/@(Uri.EscapeDataString(video.Title)).png" alt="">
                                 <div class="caption">

--- a/ToBeRenamed/Pages/Videos/Index.cshtml
+++ b/ToBeRenamed/Pages/Videos/Index.cshtml
@@ -1,8 +1,56 @@
 @page "{id:int}"
 @model IndexModel
 @{
-    ViewData["Title"] = @Model.Title;
+    ViewData["Title"] = @Model.Video.Title;
 }
 
-<h1>Title: @Model.Title</h1>
-<h4>Description: @Model.Description</h4>
+<h1>Title: @Model.Video.Title</h1>
+<h4>Description: @Model.Video.Description</h4>
+
+<br>
+
+@* 1. The <iframe> (and video player) will replace this <div> tag.  *@
+<div id="player"></div>
+
+<script>
+    // 2. This code loads the IFrame Player API code asynchronously.
+    var tag = document.createElement('script');
+
+    tag.src = "https://www.youtube.com/iframe_api";
+    var firstScriptTag = document.getElementsByTagName('script')[0];
+    firstScriptTag.parentNode.insertBefore(tag, firstScriptTag);
+
+    // 3. This function creates an <iframe> (and YouTube player)
+    //    after the API code downloads.
+    var player;
+    function onYouTubeIframeAPIReady() {
+        player = new YT.Player('player', {
+            height: '390',
+            width: '640',
+            videoId: '@Model.Video.Url',
+            events: {
+                'onReady': onPlayerReady,
+                'onStateChange': onPlayerStateChange
+            }
+        });
+    }
+
+    // 4. The API will call this function when the video player is ready.
+    function onPlayerReady(event) {
+        event.target.playVideo();
+    }
+
+    // 5. The API calls this function when the player's state changes.
+    //    The function indicates that when playing a video (state=1),
+    //    the player should play for six seconds and then stop.
+    var done = false;
+    function onPlayerStateChange(event) {
+        if (event.data == YT.PlayerState.PLAYING && !done) {
+            setTimeout(stopVideo, 6000);
+            done = true;
+        }
+    }
+    function stopVideo() {
+        player.stopVideo();
+    }
+</script>

--- a/ToBeRenamed/Pages/Videos/Index.cshtml
+++ b/ToBeRenamed/Pages/Videos/Index.cshtml
@@ -1,0 +1,8 @@
+@page "{id:int}"
+@model IndexModel
+@{
+    ViewData["Title"] = @Model.Title;
+}
+
+<h1>Title: @Model.Title</h1>
+<h4>Description: @Model.Description</h4>

--- a/ToBeRenamed/Pages/Videos/Index.cshtml.cs
+++ b/ToBeRenamed/Pages/Videos/Index.cshtml.cs
@@ -19,16 +19,11 @@ namespace ToBeRenamed.Pages.Videos
         [BindProperty(SupportsGet = true)]
         public int Id { get; set; }
         
-        public string Title { get; set; }
-        
-        public string Description { get; set; }
+        public VideoDto Video { get; set; }
         
         public async Task<IActionResult> OnGetAsync()
         {
-            var video = await _mediator.Send(new GetVideoById(Id));
-
-            Title = video.Title;
-            Description = video.Description;
+            Video = await _mediator.Send(new GetVideoById(Id));
             
             return Page();
         }

--- a/ToBeRenamed/Pages/Videos/Index.cshtml.cs
+++ b/ToBeRenamed/Pages/Videos/Index.cshtml.cs
@@ -1,0 +1,36 @@
+using System.Threading.Tasks;
+using MediatR;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using ToBeRenamed.Dtos;
+using ToBeRenamed.Queries;
+
+namespace ToBeRenamed.Pages.Videos
+{
+    public class IndexModel : PageModel
+    {
+        private readonly IMediator _mediator;
+
+        public IndexModel(IMediator mediator)
+        {
+            _mediator = mediator;
+        }
+        
+        [BindProperty(SupportsGet = true)]
+        public int Id { get; set; }
+        
+        public string Title { get; set; }
+        
+        public string Description { get; set; }
+        
+        public async Task<IActionResult> OnGetAsync()
+        {
+            var video = await _mediator.Send(new GetVideoById(Id));
+
+            Title = video.Title;
+            Description = video.Description;
+            
+            return Page();
+        }
+    }
+}

--- a/ToBeRenamed/Queries/GetVideoById.cs
+++ b/ToBeRenamed/Queries/GetVideoById.cs
@@ -1,0 +1,15 @@
+using MediatR;
+using ToBeRenamed.Dtos;
+
+namespace ToBeRenamed.Queries
+{
+    public class GetVideoById : IRequest<VideoDto>
+    {
+        public int Id { get; }
+
+        public GetVideoById(int id)
+        {
+            Id = id;
+        }
+    }
+}

--- a/ToBeRenamed/Queries/GetVideoByIdHandler.cs
+++ b/ToBeRenamed/Queries/GetVideoByIdHandler.cs
@@ -1,0 +1,33 @@
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Dapper;
+using MediatR;
+using ToBeRenamed.Dtos;
+using ToBeRenamed.Factories;
+
+namespace ToBeRenamed.Queries
+{
+    public class GetVideoByIdHandler : IRequestHandler<GetVideoById, VideoDto>
+    {
+        private readonly ISqlConnectionFactory _sqlConnectionFactory;
+        
+        public GetVideoByIdHandler(ISqlConnectionFactory sqlConnectionFactory)
+        {
+            _sqlConnectionFactory = sqlConnectionFactory;
+        }
+
+        public async Task<VideoDto> Handle(GetVideoById request, CancellationToken cancellationToken)
+        {
+            const string getVideoSql = @"
+                SELECT title, description
+                FROM plum.videos
+                WHERE id = @Id";
+
+            using (var conn = _sqlConnectionFactory.GetSqlConnection())
+            {
+                return (await conn.QueryAsync<VideoDto>(getVideoSql, new {request.Id})).Single();
+            }
+        }
+    }
+}

--- a/ToBeRenamed/Queries/GetVideoByIdHandler.cs
+++ b/ToBeRenamed/Queries/GetVideoByIdHandler.cs
@@ -20,9 +20,11 @@ namespace ToBeRenamed.Queries
         public async Task<VideoDto> Handle(GetVideoById request, CancellationToken cancellationToken)
         {
             const string getVideoSql = @"
-                SELECT title, description
+                SELECT videos.title, videos.description, video_urls.url
                 FROM plum.videos
-                WHERE id = @Id";
+                INNER JOIN plum.video_urls
+                ON videos.video_url_id = video_urls.id
+                WHERE videos.id = @Id";
 
             using (var conn = _sqlConnectionFactory.GetSqlConnection())
             {

--- a/ToBeRenamed/Queries/GetVideosOfLibraryHandler.cs
+++ b/ToBeRenamed/Queries/GetVideosOfLibraryHandler.cs
@@ -22,7 +22,8 @@ namespace ToBeRenamed.Queries
             const string sql = @"
                 SELECT
                     videos.title,
-                    videos.description
+                    videos.description,
+                    videos.id
                 FROM plum.videos
                 INNER JOIN plum.memberships mem
                 ON videos.library_id = mem.library_id

--- a/ToBeRenamed/ToBeRenamed.csproj
+++ b/ToBeRenamed/ToBeRenamed.csproj
@@ -17,7 +17,6 @@
 
   <ItemGroup>
     <Compile Remove="Pages\Videos\EmptyClass.cs" />
-    <Compile Remove="Pages\Videos\Index.cshtml.cs" />
   </ItemGroup>
   <ItemGroup>
     <Content Remove="Pages\Videos\Create.cshtml" />


### PR DESCRIPTION
### **NOTE: The "Create video pages" pull request (#62) should be merged into master before this**

To test this out, simply go over to youtube, choose a random video, and use that URL for that video as the URL when creating the video. The URL MUST have the same pattern as this link though: `https://www.youtube.com/watch?v=-O5kNPlUV7w`

Once you do that it should load up the video once you visit the page. The video will start playing for 6 seconds and then stop. This is because that is what the default example does on the youtube API website (`https://developers.google.com/youtube/iframe_api_reference`) and I just left it that way for now. We can change that whenever.

Notice that using invalid youtube URLs still works, but an error just appears where the video normally would. We should implement some type of validation for the URL when creating the video to prevent this in the future.

Lastly, notice that I'm parsing the video identifier from the youtube URL (For example `-O5kNPlUV7w` from `https://www.youtube.com/watch?v=-O5kNPlUV7w`). I'm only storing this identifier and not the whole youtube URL since that's all the API needs. We can change that in the future or just stick with it.